### PR TITLE
Make 'install' task depend on shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 }
 
 plugins {
+    id 'maven'
     id "org.jetbrains.kotlin.jvm" version "1.2.10"
     id "org.jetbrains.kotlin.kapt" version "1.2.10"
     id "com.github.johnrengelman.shadow" version "1.2.4"
@@ -53,6 +54,7 @@ shadowJar {
     classifier = null // Remove "-all" suffix from output file name
 }
 build.dependsOn shadowJar
+install.dependsOn shadowJar
 if (!isJitpack) {
     signArchives.dependsOn shadowJar
 }


### PR DESCRIPTION
This ensures that shadowing runs properly on JitPack, which uses
'gradle install'